### PR TITLE
Use the enum names in self.compatible_ids in common_ids.py

### DIFF
--- a/pitopcommon/common_ids.py
+++ b/pitopcommon/common_ids.py
@@ -82,42 +82,42 @@ class Peripheral:
 
     def config_pulse(self):
         self.id = PeripheralID.pi_top_pulse
-        self.compatible_ids = list()
+        self.compatible_ids = [PeripheralID.pi_top_proto_plus]
         self.name = "pi-topPULSE"
         self.type = PeripheralType.hat
         self.addr = 0x24
 
     def config_speaker_l(self):
         self.id = PeripheralID.pi_top_speaker_l
-        self.compatible_ids = [2, 3]
+        self.compatible_ids = [PeripheralID.pi_top_speaker_r, PeripheralID.pi_top_speaker_m]
         self.name = "pi-topSPEAKER-v1-Left"
         self.type = PeripheralType.addon
         self.addr = 0x71
 
     def config_speaker_m(self):
         self.id = PeripheralID.pi_top_speaker_m
-        self.compatible_ids = [1, 3]
+        self.compatible_ids = [PeripheralID.pi_top_speaker_l, PeripheralID.pi_top_speaker_r]
         self.name = "pi-topSPEAKER-v1-Mono"
         self.type = PeripheralType.addon
         self.addr = 0x73
 
     def config_speaker_r(self):
         self.id = PeripheralID.pi_top_speaker_r
-        self.compatible_ids = [1, 2]
+        self.compatible_ids = [PeripheralID.pi_top_speaker_l, PeripheralID.pi_top_speaker_m]
         self.name = "pi-topSPEAKER-v1-Right"
         self.type = PeripheralType.addon
         self.addr = 0x72
 
     def config_speaker_v2(self):
         self.id = PeripheralID.pi_top_speaker_v2
-        self.compatible_ids = [5]
+        self.compatible_ids = [PeripheralID.pi_top_proto_plus]
         self.name = "pi-topSPEAKER-v2"
         self.type = PeripheralType.addon
         self.addr = 0x43
 
     def config_proto_plus(self):
         self.id = PeripheralID.pi_top_proto_plus
-        self.compatible_ids = [0, 4]
+        self.compatible_ids = [PeripheralID.pi_top_pulse, PeripheralID.pi_top_speaker_v2]
         self.name = "pi-topPROTO+"
         self.type = PeripheralType.addon
         self.addr = 0x2A


### PR DESCRIPTION
Use the enum names in self.compatible_ids in common_ids.py. This allows several pi-topSPEAKER-v1-* speakers to be used in different configurations. Without this I can't use a pi-topSPEAKER-v1-Right at the same time as a pi-topSPEAKER-v1-Left.

Without the enum values `attempt_enable_peripheral_by_name` fails in pt-device-manager.

ptdm_peripheral_manager.py:353
```
                if (
                    enabled_peripheral.id != current_peripheral.id
                    and current_peripheral.id not in enabled_peripheral.compatible_ids <- current_peripheral.id is the Enum Value, enabled_peripheral.compatible_ids  is a list of integers
                ):
```